### PR TITLE
fix(section-1): corrects relative path in src/demos/section-1/001_providing-a-service-01.ts

### DIFF
--- a/src/demos/section-1/001_providing-a-service-01.ts
+++ b/src/demos/section-1/001_providing-a-service-01.ts
@@ -27,7 +27,7 @@ const InMemoryCache = Cache.of({
 const FileSystemCache = Cache.of({
   lookup: (key) =>
     Effect.tryPromise({
-      try: () => fs.readFile(`src/demos/session-1/cache/${key}`, "utf-8"),
+      try: () => fs.readFile(`src/demos/section-1/cache/${key}`, "utf-8"),
       catch: () => new CacheMissError({ message: `Failed to read file for cache key: "${key}"` })
     })
 })


### PR DESCRIPTION
Minor change to allow running the first demo of section 1.

### What?

`src/demos/section-1/001_providing-a-service-01.ts` raises a **CacheMissError** when trying to run it.

### Why?

The `lookup()` method in `FileSystemCache` was attempting to read from `src/demos/session-1/cache/${key}`.  
But the correct path is `src/demos/section-1/cache/${key}`. 

#### Before

```typescript
try: () => fs.readFile(`src/demos/session-1/cache/${key}`, "utf-8"),
```

#### After

```typescript
try: () => fs.readFile(`src/demos/section-1/cache/${key}`, "utf-8"),
```

### Testing

With this fix, the expected output is:

```shell
% pnpm exercise src/demos/section-1/001_providing-a-service-01.ts

in-memory-value1
file-value2
````

Previously, the output was:

```shell
[…]
in-memory-value1
CacheMissError: Failed to read file for cache key: "key2"
````

### My environment

* OS: macOS
* Node.js version: v24.1.0
* Package manager: pnpm@10.5.1
* Command used: `pnpm exercise src/demos/section-1/001_providing-a-service-01.ts`
